### PR TITLE
Fix/endpoint calc cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nestjs/swagger": "^6.1.4",
     "cache-manager": "^5.2.0",
     "cache-manager-redis-yet": "^4.1.1",
+    "decimal.js": "^10.4.3",
     "ethers": "^5.3.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/src/blockchain/dpos.contract.ts
+++ b/src/blockchain/dpos.contract.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ethers } from 'ethers';
-import { ValidatorData } from 'src/utils/types';
+import { ValidatorData } from '../utils/types';
 
 @Injectable()
 export class DposContract {

--- a/src/github/github.module.ts
+++ b/src/github/github.module.ts
@@ -5,7 +5,7 @@ import { GitHubService } from './github.service';
 import { GitHubController } from './github.controller';
 import { GraphQLRequestModule } from '@golevelup/nestjs-graphql-request';
 import { GraphQLService } from './graphql.connector.service';
-import { buildCacheConfig } from 'src/config/cacheConfig';
+import { buildCacheConfig } from '../config/cacheConfig';
 
 @Module({
   imports: [

--- a/src/github/github.service.ts
+++ b/src/github/github.service.ts
@@ -60,7 +60,7 @@ export class GitHubService {
         try {
           const since = new Date(
             new Date().getUTCFullYear(),
-            new Date().getMonth(),
+            new Date().getMonth() - 1,
             1,
             0,
             0,
@@ -119,9 +119,10 @@ export class GitHubService {
                   );
                 countedCommitData.push(...commitHistory);
                 countedCommitData = Array.from(new Set(countedCommitData));
-                totalCommits +=
+                const uniquieCommitsForBranch =
                   Number(edge.node.target.history.totalCount || 0) -
                   duplicateOrMergeCommits.length;
+                totalCommits += uniquieCommitsForBranch;
               }
             }
           });

--- a/src/github/github.service.ts
+++ b/src/github/github.service.ts
@@ -3,7 +3,6 @@ import {
   InternalServerErrorException,
   Logger,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { GraphQLService } from './graphql.connector.service';
 
 interface CommitData {
@@ -14,14 +13,11 @@ interface CommitData {
 @Injectable()
 export class GitHubService {
   private readonly logger = new Logger(GitHubService.name);
-  constructor(
-    private configService: ConfigService,
-    private readonly graphQLService: GraphQLService,
-  ) {}
+  constructor(private readonly graphQLService: GraphQLService) {}
 
   async getRepoNames() {
-    let returnData;
-    let endCursor;
+    let returnData: any;
+    let endCursor: string;
     const repoNames = [] as string[];
     let isDone = false;
     while (!isDone) {

--- a/src/node/node.controller.ts
+++ b/src/node/node.controller.ts
@@ -7,8 +7,8 @@ import {
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { NodeService } from './node.service';
-import { StakingService } from 'src/staking/staking.service';
-import { TokenService } from 'src/token/token.service';
+import { StakingService } from '../staking/staking.service';
+import { TokenService } from '../token/token.service';
 import { BigNumber } from 'ethers';
 
 @ApiTags('Validators')
@@ -79,7 +79,7 @@ export class NodeController {
   @CacheTTL(36000000)
   @UseInterceptors(CacheInterceptor)
   async cumulativeRewards() {
-    const INITIAL_SUPPLY = '10119799574107498232500000000';
+    const INITIAL_SUPPLY = '10000000000000000000000000000';
     const currentSupply = await this.tokenService.totalSupply();
     return BigNumber.from(currentSupply)
       .sub(BigNumber.from(INITIAL_SUPPLY).div(BigNumber.from(10).pow(18)))

--- a/src/node/node.controller.ts
+++ b/src/node/node.controller.ts
@@ -15,15 +15,17 @@ export class NodeController {
 
   @Get()
   async validatorData() {
-    const activeMainnet = (await this.nodeService.noActiveValidators())
-      .totalActive;
-    const activeTestnet = (await this.nodeService.noActiveValidators(true))
-      .totalActive;
+    const activeMainnet = (
+      await this.nodeService.noActiveValidators()
+    ).totalActive.toString();
+    const activeTestnet = (
+      await this.nodeService.noActiveValidators(true)
+    ).totalActive.toString();
     // const cumulativeCommission = await this.nodeService.cumulativeCommisson();
     return {
       activeMainnet,
       activeTestnet,
-      cumulativeCommission: 0,
+      cumulativeCommission: '0',
     };
   }
 
@@ -35,7 +37,7 @@ export class NodeController {
   @CacheTTL(36000000)
   @UseInterceptors(CacheInterceptor)
   async totalActiveValidatorsMainnet() {
-    return (await this.nodeService.noActiveValidators()).totalActive;
+    return (await this.nodeService.noActiveValidators()).totalActive.toString();
   }
 
   /**
@@ -46,7 +48,9 @@ export class NodeController {
   @CacheTTL(36000000)
   @UseInterceptors(CacheInterceptor)
   async totaltotalActiveValidatorsTestnet() {
-    return (await this.nodeService.noActiveValidators(true)).totalActive;
+    return (
+      await this.nodeService.noActiveValidators(true)
+    ).totalActive.toString();
   }
 
   /**
@@ -58,6 +62,6 @@ export class NodeController {
   @UseInterceptors(CacheInterceptor)
   async cumulativeCommission() {
     // return await this.nodeService.cumulativeCommisson();
-    return 0;
+    return '0';
   }
 }

--- a/src/node/node.controller.ts
+++ b/src/node/node.controller.ts
@@ -7,11 +7,17 @@ import {
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { NodeService } from './node.service';
+import { StakingService } from 'src/staking/staking.service';
+import { TokenService } from 'src/token/token.service';
+import { BigNumber } from 'ethers';
 
 @ApiTags('Validators')
 @Controller('validators')
 export class NodeController {
-  constructor(private readonly nodeService: NodeService) {}
+  constructor(
+    private readonly nodeService: NodeService,
+    private readonly tokenService: TokenService,
+  ) {}
 
   @Get()
   async validatorData() {
@@ -63,5 +69,20 @@ export class NodeController {
   async cumulativeCommission() {
     // return await this.nodeService.cumulativeCommisson();
     return '0';
+  }
+
+  /**
+   * Returns the cumulative rewards earned by Taraxa Validators on the Taraxa Mainnet
+   * @returns cumulative rewards in ETH
+   */
+  @Get('cumulativeRewards')
+  @CacheTTL(36000000)
+  @UseInterceptors(CacheInterceptor)
+  async cumulativeRewards() {
+    const INITIAL_SUPPLY = '10119799574107498232500000000';
+    const currentSupply = await this.tokenService.totalSupply();
+    return BigNumber.from(currentSupply)
+      .sub(BigNumber.from(INITIAL_SUPPLY).div(BigNumber.from(10).pow(18)))
+      .toString();
   }
 }

--- a/src/node/node.controller.ts
+++ b/src/node/node.controller.ts
@@ -19,11 +19,11 @@ export class NodeController {
       .totalActive;
     const activeTestnet = (await this.nodeService.noActiveValidators(true))
       .totalActive;
-    const cumulativeCommission = await this.nodeService.cumulativeCommisson();
+    // const cumulativeCommission = await this.nodeService.cumulativeCommisson();
     return {
       activeMainnet,
       activeTestnet,
-      cumulativeCommission,
+      cumulativeCommission: 0,
     };
   }
 
@@ -57,6 +57,7 @@ export class NodeController {
   @CacheTTL(36000000)
   @UseInterceptors(CacheInterceptor)
   async cumulativeCommission() {
-    return await this.nodeService.cumulativeCommisson();
+    // return await this.nodeService.cumulativeCommisson();
+    return 0;
   }
 }

--- a/src/node/node.controller.ts
+++ b/src/node/node.controller.ts
@@ -7,7 +7,6 @@ import {
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { NodeService } from './node.service';
-import { StakingService } from '../staking/staking.service';
 import { TokenService } from '../token/token.service';
 import { BigNumber } from 'ethers';
 

--- a/src/node/node.module.ts
+++ b/src/node/node.module.ts
@@ -1,13 +1,15 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module, CacheModule } from '@nestjs/common';
-import { BlockchainModule } from 'src/blockchain/blockchain.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { NodeController } from './node.controller';
 import { NodeService } from './node.service';
 import { buildCacheConfig } from 'src/config/cacheConfig';
+import { StakingModule } from 'src/staking/staking.module';
+import { TokenModule } from 'src/token/token.module';
 @Module({
   imports: [
-    BlockchainModule,
+    StakingModule,
+    TokenModule,
     ConfigModule,
     HttpModule,
     CacheModule.registerAsync({

--- a/src/node/node.module.ts
+++ b/src/node/node.module.ts
@@ -3,12 +3,10 @@ import { Module, CacheModule } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { NodeController } from './node.controller';
 import { NodeService } from './node.service';
-import { buildCacheConfig } from 'src/config/cacheConfig';
-import { StakingModule } from 'src/staking/staking.module';
-import { TokenModule } from 'src/token/token.module';
+import { buildCacheConfig } from '../config/cacheConfig';
+import { TokenModule } from '../token/token.module';
 @Module({
   imports: [
-    StakingModule,
     TokenModule,
     ConfigModule,
     HttpModule,

--- a/src/node/node.service.ts
+++ b/src/node/node.service.ts
@@ -57,14 +57,14 @@ export class NodeService {
     };
   }
 
-  async cumulativeCommisson() {
-    let cumulativeCommission = BigNumber.from(0);
-    const validators = await this.dposContract.fetchDelegationData();
-    validators.forEach((validator) => {
-      cumulativeCommission = cumulativeCommission.add(
-        BigNumber.from(validator.info.commission_reward),
-      );
-    });
-    return ethers.utils.formatEther(cumulativeCommission.toString());
-  }
+  // async cumulativeCommisson() {
+  //   let cumulativeCommission = BigNumber.from(0);
+  //   const validators = await this.dposContract.fetchDelegationData();
+  //   validators.forEach((validator) => {
+  //     cumulativeCommission = cumulativeCommission.add(
+  //       BigNumber.from(validator.info.commission_reward),
+  //     );
+  //   });
+  //   return ethers.utils.formatEther(cumulativeCommission.toString());
+  // }
 }

--- a/src/node/node.service.ts
+++ b/src/node/node.service.ts
@@ -6,16 +6,12 @@ import {
   Logger,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { BigNumber, ethers } from 'ethers';
 import { catchError, firstValueFrom, map } from 'rxjs';
-import { DposContract } from 'src/blockchain/dpos.contract';
-import { ValidatorData } from 'src/utils/types';
 
 @Injectable()
 export class NodeService {
   private readonly logger = new Logger(NodeService.name);
   constructor(
-    private readonly dposContract: DposContract,
     private readonly configService: ConfigService,
     private readonly httpService: HttpService,
   ) {}

--- a/src/staking/delegation.service.ts
+++ b/src/staking/delegation.service.ts
@@ -5,7 +5,7 @@ import { ValidatorData } from '../utils/types';
 
 @Injectable()
 export class DelegationService {
-  constructor(private readonly dposContract: DposContract) { }
+  constructor(private readonly dposContract: DposContract) {}
 
   async totalDelegated() {
     const validators = await this.dposContract.fetchDelegationData();

--- a/src/staking/staking.controller.ts
+++ b/src/staking/staking.controller.ts
@@ -6,12 +6,12 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { DelegationService } from './delegation.service';
+import { StakingService } from './staking.service';
 
 @ApiTags('Staking')
 @Controller('staking')
 export class StakingController {
-  constructor(private readonly delegationService: DelegationService) {}
+  constructor(private readonly delegationService: StakingService) {}
 
   @Get()
   async stakingData() {

--- a/src/staking/staking.controller.ts
+++ b/src/staking/staking.controller.ts
@@ -11,14 +11,14 @@ import { StakingService } from './staking.service';
 @ApiTags('Staking')
 @Controller('staking')
 export class StakingController {
-  constructor(private readonly delegationService: StakingService) {}
+  constructor(private readonly stakingService: StakingService) {}
 
   @Get()
   async stakingData() {
-    const totalStaked = await this.delegationService.totalDelegated();
-    const totalDelegated = await this.delegationService.totalDelegated();
+    const totalStaked = await this.stakingService.totalDelegated();
+    const totalDelegated = await this.stakingService.totalDelegated();
     const avgValidatorCommission = (
-      await this.delegationService.averageWeightedCommission()
+      await this.stakingService.averageWeightedCommission()
     ).averageWeightedCommission.toString();
     const avgStakingYield = await this.avgStakingYield();
     return {
@@ -36,7 +36,7 @@ export class StakingController {
   @CacheTTL(36000000)
   @UseInterceptors(CacheInterceptor)
   async totalStaked() {
-    return await this.delegationService.totalDelegated();
+    return await this.stakingService.totalDelegated();
   }
 
   /**
@@ -47,7 +47,7 @@ export class StakingController {
   @CacheTTL(36000000)
   @UseInterceptors(CacheInterceptor)
   async totalDelegated() {
-    return await this.delegationService.totalDelegated();
+    return await this.stakingService.totalDelegated();
   }
 
   /**
@@ -58,7 +58,7 @@ export class StakingController {
   @CacheTTL(36000000)
   @UseInterceptors(CacheInterceptor)
   async avgValidatorCommission() {
-    return (await this.delegationService.averageWeightedCommission())
+    return (await this.stakingService.averageWeightedCommission())
       .averageWeightedCommission;
   }
 

--- a/src/staking/staking.controller.ts
+++ b/src/staking/staking.controller.ts
@@ -11,9 +11,7 @@ import { DelegationService } from './delegation.service';
 @ApiTags('Staking')
 @Controller('staking')
 export class StakingController {
-  constructor(
-    private readonly delegationService: DelegationService,
-  ) {}
+  constructor(private readonly delegationService: DelegationService) {}
 
   @Get()
   async stakingData() {
@@ -21,8 +19,8 @@ export class StakingController {
     const totalDelegated = await this.delegationService.totalDelegated();
     const avgValidatorCommission = (
       await this.delegationService.averageWeightedCommission()
-    ).averageWeightedCommission;
-    const avgStakingYield = 20 - (await this.avgValidatorCommission());
+    ).averageWeightedCommission.toString();
+    const avgStakingYield = await this.avgStakingYield();
     return {
       totalStaked,
       totalDelegated,
@@ -72,6 +70,9 @@ export class StakingController {
   @CacheTTL(36000000)
   @UseInterceptors(CacheInterceptor)
   async avgStakingYield() {
-    return 20 - (await this.avgValidatorCommission());
+    const avgValidatorCommission = await this.avgValidatorCommission();
+    const avgStakingYield =
+      20 * (1 - parseFloat(avgValidatorCommission.toString()));
+    return avgStakingYield.toString();
   }
 }

--- a/src/staking/staking.module.ts
+++ b/src/staking/staking.module.ts
@@ -1,7 +1,7 @@
 import { CacheModule, Module } from '@nestjs/common';
 import { BlockchainModule } from 'src/blockchain/blockchain.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { DelegationService } from './delegation.service';
+import { StakingService } from './staking.service';
 import { StakingController } from './staking.controller';
 import { buildCacheConfig } from 'src/config/cacheConfig';
 
@@ -17,7 +17,7 @@ import { buildCacheConfig } from 'src/config/cacheConfig';
     }),
   ],
   controllers: [StakingController],
-  providers: [DelegationService],
-  exports: [DelegationService],
+  providers: [StakingService],
+  exports: [StakingService],
 })
 export class StakingModule {}

--- a/src/staking/staking.module.ts
+++ b/src/staking/staking.module.ts
@@ -18,5 +18,6 @@ import { buildCacheConfig } from 'src/config/cacheConfig';
   ],
   controllers: [StakingController],
   providers: [DelegationService],
+  exports: [DelegationService],
 })
 export class StakingModule {}

--- a/src/staking/staking.module.ts
+++ b/src/staking/staking.module.ts
@@ -1,9 +1,9 @@
 import { CacheModule, Module } from '@nestjs/common';
-import { BlockchainModule } from 'src/blockchain/blockchain.module';
+import { BlockchainModule } from '../blockchain/blockchain.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { StakingService } from './staking.service';
 import { StakingController } from './staking.controller';
-import { buildCacheConfig } from 'src/config/cacheConfig';
+import { buildCacheConfig } from '../config/cacheConfig';
 
 @Module({
   imports: [

--- a/src/staking/staking.service.ts
+++ b/src/staking/staking.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { BigNumber } from 'ethers';
 import { DposContract } from 'src/blockchain/dpos.contract';
 import { ValidatorData } from '../utils/types';
-
+import { Decimal } from 'decimal.js';
 @Injectable()
 export class StakingService {
   constructor(private readonly dposContract: DposContract) {}
@@ -35,10 +35,10 @@ export class StakingService {
       );
     });
 
-    const weightedAverage =
-      parseFloat(totalWeightedCommission.toString()) /
-      parseFloat(totalDelegation.toString()) /
-      100;
+    const weightedAverage = new Decimal(totalWeightedCommission.toString())
+      .div(new Decimal(totalDelegation.toString()))
+      .div(new Decimal(100))
+      .toString();
 
     return {
       totalDelegated: totalDelegation,

--- a/src/staking/staking.service.ts
+++ b/src/staking/staking.service.ts
@@ -4,7 +4,7 @@ import { DposContract } from 'src/blockchain/dpos.contract';
 import { ValidatorData } from '../utils/types';
 
 @Injectable()
-export class DelegationService {
+export class StakingService {
   constructor(private readonly dposContract: DposContract) {}
 
   async totalDelegated() {

--- a/src/staking/staking.service.ts
+++ b/src/staking/staking.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { BigNumber } from 'ethers';
-import { DposContract } from 'src/blockchain/dpos.contract';
+import { DposContract } from '../blockchain/dpos.contract';
 import { ValidatorData } from '../utils/types';
 import { Decimal } from 'decimal.js';
 @Injectable()

--- a/src/token/token.controller.ts
+++ b/src/token/token.controller.ts
@@ -44,10 +44,10 @@ export class TokenController {
    * @returns price as float
    */
   @Get('price')
-  @CacheTTL(30000)
+  @CacheTTL(60000)
   @UseInterceptors(CacheInterceptor)
   async getPrice() {
-    return await this.tokenService.getPrice();
+    return (await this.tokenService.getPrice()).toString();
   }
 
   /**
@@ -77,7 +77,9 @@ export class TokenController {
    */
   @Get('totalCirculating')
   async totalInCirculation() {
-    return (await this.tokenService.marketDetails()).circulatingSupply;
+    return (
+      await this.tokenService.marketDetails()
+    ).circulatingSupply.toString();
   }
   /**
    * Returns the current TARA stakign ratio
@@ -95,6 +97,6 @@ export class TokenController {
    */
   @Get('mktCap')
   async mktCap() {
-    return (await this.tokenService.marketDetails()).marketCap;
+    return (await this.tokenService.marketDetails()).marketCap.toString();
   }
 }

--- a/src/token/token.controller.ts
+++ b/src/token/token.controller.ts
@@ -47,7 +47,7 @@ export class TokenController {
   @CacheTTL(60000)
   @UseInterceptors(CacheInterceptor)
   async getPrice() {
-    return (await this.tokenService.getPrice()).toString();
+    return (await this.tokenService.marketDetails()).price.toString();
   }
 
   /**

--- a/src/token/token.module.ts
+++ b/src/token/token.module.ts
@@ -1,11 +1,11 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module, CacheModule } from '@nestjs/common';
-import { BlockchainModule } from 'src/blockchain/blockchain.module';
+import { BlockchainModule } from '../blockchain/blockchain.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TokenController } from './token.controller';
 import { TokenService } from './token.service';
-import { buildCacheConfig } from 'src/config/cacheConfig';
-import { StakingModule } from 'src/staking/staking.module';
+import { buildCacheConfig } from '../config/cacheConfig';
+import { StakingModule } from '../staking/staking.module';
 
 @Module({
   imports: [

--- a/src/token/token.module.ts
+++ b/src/token/token.module.ts
@@ -5,12 +5,14 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TokenController } from './token.controller';
 import { TokenService } from './token.service';
 import { buildCacheConfig } from 'src/config/cacheConfig';
+import { StakingModule } from 'src/staking/staking.module';
 
 @Module({
   imports: [
     BlockchainModule,
     ConfigModule,
     HttpModule,
+    StakingModule,
     CacheModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/src/token/token.service.ts
+++ b/src/token/token.service.ts
@@ -13,7 +13,7 @@ import { HttpService } from '@nestjs/axios';
 import { firstValueFrom, catchError, map } from 'rxjs';
 import { Cache } from 'cache-manager';
 import { MarketDetails } from '../utils/types';
-import { DelegationService } from 'src/staking/delegation.service';
+import { StakingService } from 'src/staking/staking.service';
 
 @Injectable()
 export class TokenService {
@@ -23,7 +23,7 @@ export class TokenService {
   constructor(
     private configService: ConfigService,
     private readonly httpService: HttpService,
-    private readonly delegationService: DelegationService,
+    private readonly delegationService: StakingService,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {
     this.ethersProvider = new ethers.providers.JsonRpcProvider(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,6 +1638,11 @@ debug@^4.0.1, debug@^4.1.1, debug@^4.3.1:
   dependencies:
     ms "2.1.2"
 
+decimal.js@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
+  integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
+
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"


### PR DESCRIPTION
- [x] Decommission `cumulativeCommission` endpoint until subgraph is done.
- [x] implements `cumulativeRewards` endpoint.
- [x] Fix contributions endpoint.
- [x] Correct avgStakingYield calculation.
- [x] Switch to 1 min cache for prices, use cacheManager.
- [x] Unify returns as strings.
- [x] Avoid floating point rounding after the 52nd bit.